### PR TITLE
add support for translatable titles and messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "illuminate/translation": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~4.0",
-        "illuminate/translation": "^5.3"
+        "illuminate/translation": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -16,9 +16,10 @@ class Flash
      *
      * @param SessionStore $session
      */
-    public function __construct(SessionStore $session)
+    public function __construct(SessionStore $session, \Illuminate\Translation\Translator $translator)
     {
         $this->session = $session;
+        $this->translator = $translator;
     }
 
     /**
@@ -33,8 +34,8 @@ class Flash
     public function create($title, $message, $level = 'info', $key = 'flash_message')
     {
         $this->session->flash($key, [
-            'title'   => $title,
-            'message' => $message,
+            'title'   => $this->translator->get($title),
+            'message' => $this->translator->get($message),
             'level'   => $level,
         ]);
 

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -73,4 +73,16 @@ class FlashTest extends TestCase
 
         $this->flash->create('Custom Title!', 'Custom Message.', 'custom_level', 'custom_flash_message');
     }
+
+    /** @test */
+    public function it_displays_translated_flash_messages()
+    {
+        $this->session->shouldReceive('flash')->with('flash_message', [
+            'title'   => 'Translated title.',
+            'message' => 'Translated message.',
+            'level'   => 'success',
+        ]);
+
+        $this->flash->success('group.translatable_title', 'group.translatable_message');
+    }
 }

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -83,6 +83,6 @@ class FlashTest extends TestCase
             'level'   => 'success',
         ]);
 
-        $this->flash->success('group.translatable_title', 'group.translatable_message');
+        $this->flash->success('flash.translatable_title', 'flash.translatable_message');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 use Gtk\FlashMessage\Flash;
 use Mockery as m;
+use Illuminate\Translation\FileLoader;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
@@ -22,12 +23,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected function getIlluminateArrayTranslator()
     {
-        $loader = new Illuminate\Translation\ArrayLoader();
-        $loader->addMessages('en', 'group', [
-            'translatable_title' => 'Translated title.',
-            'translatable_message' => 'Translated message.'
-        ]);
-
+        $loader = new FileLoader(new \Illuminate\Filesystem\Filesystem, __DIR__);
+        $loader->load('en', 'flash');
         return new Illuminate\Translation\Translator($loader, 'en');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,22 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->session = m::mock('Gtk\FlashMessage\SessionStore');
+        $this->flash = new Flash($this->session, $this->getIlluminateArrayTranslator());
+    }
 
-        $this->flash = new Flash($this->session);
+    /**
+     * Array translator with some test values
+     *
+     * @return \Illuminate\Translation\Translator
+     */
+    protected function getIlluminateArrayTranslator()
+    {
+        $loader = new Illuminate\Translation\ArrayLoader();
+        $loader->addMessages('en', 'group', [
+            'translatable_title' => 'Translated title.',
+            'translatable_message' => 'Translated message.'
+        ]);
+
+        return new Illuminate\Translation\Translator($loader, 'en');
     }
 }

--- a/tests/en/flash.php
+++ b/tests/en/flash.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'translatable_title' => 'Translated title.',
+    'translatable_message' => 'Translated message.'
+];


### PR DESCRIPTION
Translation keys could be passed like regular `$title` or `$message` argument